### PR TITLE
Fix decoding of a query string

### DIFF
--- a/src/http/route.js
+++ b/src/http/route.js
@@ -67,7 +67,8 @@ function parseQuery(list) {
     const query = {};
     for (var i = 0, len = list.length; i < len; i++) {
         const sep = list[i].split('=');
-        query[sep[0]] = typecast(sep[1]);
+        const key = decodeURIComponent(sep[0]);
+        query[key] = typecast(sep[1]);
     }
     return query;
 }
@@ -83,7 +84,7 @@ function parseParams(list, names) {
 }
 
 function typecast(value) {
-    const val = decodeURI(value);
+    const val = decodeURIComponent(value);
     if (isNaN(val)) {
         switch (val) {
             case 'true':
@@ -117,7 +118,7 @@ function typecast(value) {
 }
 
 function cast(type, value) {
-    const val = decodeURI(value);
+    const val = decodeURIComponent(value);
     switch (type) {
         case 'number':
             if (isNaN(val)) {

--- a/test/http/controller/test/get4.js
+++ b/test/http/controller/test/get4.js
@@ -1,0 +1,14 @@
+var assert = require('assert');
+
+module.exports.GET = function (req, res) {
+    var parameters = req.parameters ? req.parameters : null;
+    var submit = req.query['\u9001\u4FE1'];
+    assert(req.requestId || req.id);
+    if (parameters === null) {
+        parameters = [];
+        for (var i in req.params) {
+            parameters.push(req.params[i]);
+        }
+    }
+    res.json({ '\u9001\u4FE1': submit, parameters: parameters });
+};

--- a/test/http/test/get4.js
+++ b/test/http/test/get4.js
@@ -1,0 +1,14 @@
+var assert = require('assert');
+
+module.exports.GET = function (req, res) {
+    var parameters = req.parameters ? req.parameters : null;
+    var submit = req.query['\u9001\u4FE1'];
+    assert(req.requestId || req.id);
+    if (parameters === null) {
+        parameters = [];
+        for (var i in req.params) {
+            parameters.push(req.params[i]);
+        }
+    }
+    res.json({ '\u9001\u4FE1': submit, parameters: parameters });
+};


### PR DESCRIPTION
This PR fixes the failure of decoding queries and params including percent encoded characters (especially special characters `=`, `:`) like JSON expression.

For example, the following query string now decoded correctly.
```
`?foo={%22text%22%3A%20%22val%201%22%2C%0A%22next%22%3A%20%22val%202%22}`.
```