### PR TITLE
Add `noDelay` option for TCP and RPC servers

### DIFF
--- a/src/http/index.js
+++ b/src/http/index.js
@@ -179,6 +179,9 @@ exports.startModule = function (cb) {
         );
         cb(error);
     });
+    server.on('connection', function (socket) {
+        socket.setNoDelay(!!config.noDelay);
+    });
     try {
         server.listen(config.port, config.host);
     } catch (error) {

--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -200,7 +200,9 @@ module.exports.startModule = function (cb) {
             exclusive: true
         });
     };
-    server = net.createServer(handleConn);
+    server = net.createServer(handleConn, function (socket) {
+        socket.setNoDelay(!!config.noDelay);
+    });
     server.on('listening', done);
     server.on('error', function __rpcOnError(error) {
         if (error.code === PORT_IN_USE) {


### PR DESCRIPTION
This PR adds noDelay option for TCP socket to improve HTTP and RPC server latency.